### PR TITLE
Remove strings lowering process

### DIFF
--- a/app/handlers/content_bases.py
+++ b/app/handlers/content_bases.py
@@ -89,7 +89,7 @@ class ContentBaseHandler(IDocumentHandler):
     def search(self, request: ContentBaseSearchRequest, Authorization: Annotated[str | None, Header()] = None):
         token_verification(Authorization)
         response = self.content_base_indexer.search(
-            search=request.search.lower(),
+            search=request.search,
             threshold=request.threshold,
             filter=request.filter
         )

--- a/app/indexer/content_bases.py
+++ b/app/indexer/content_bases.py
@@ -36,7 +36,7 @@ class ContentBaseIndexer(IDocumentIndexer):
             self.storage.delete(ids=ids)
 
         docs = [
-            Document(page_content=text.lower(), metadata=metadatas)
+            Document(page_content=text, metadata=metadatas)
             for text in texts
         ]
 

--- a/app/loaders/loaders.py
+++ b/app/loaders/loaders.py
@@ -54,7 +54,7 @@ class DataLoader:
         for i, page in enumerate(pages):
             text = page.page_content
             if text:
-                raw_text += text.lower()
+                raw_text += text
         return raw_text
 
 
@@ -85,7 +85,7 @@ class TxtLoader(DocumentLoader):
         pages = self.load()
         split_pages = []
         for page in pages:
-            page_content = page.page_content.lower()
+            page_content = page.page_content
             metadatas = page.metadata
             metadatas.update({"full_page": page_content})
 
@@ -118,7 +118,7 @@ class PDFLoader(DocumentLoader):
         split_pages = []
 
         for page in pages:
-            page_content = page.page_content.lower()
+            page_content = page.page_content
             metadatas = page.metadata
             metadatas.update({"full_page": page_content})
 
@@ -134,7 +134,7 @@ class PDFLoader(DocumentLoader):
         for i, page in enumerate(pages):
             text = page.page_content
             if text:
-                raw_text += text.lower()
+                raw_text += text
         return raw_text
 
 
@@ -155,7 +155,7 @@ class DocxLoader(DocumentLoader):
         pages = self.load()
         split_pages = []
         for page in pages:
-            page_content = page.page_content.lower()
+            page_content = page.page_content
             metadatas = page.metadata
             metadatas.update({"full_page": page_content})
 
@@ -202,7 +202,7 @@ class XlsxLoader(DocumentLoader):
         pages = self.load()
         split_pages = []
         for page in pages:
-            page_content = page.page_content.lower()
+            page_content = page.page_content
             metadatas = page.metadata
             metadatas.update({"full_page": page_content})
 
@@ -230,7 +230,7 @@ class URLsLoader(DocumentLoader):
 
         pages = self.loader.load_and_split()
         for page in pages:
-            page_content = page.page_content.lower()
+            page_content = page.page_content
             metadatas = page.metadata
             metadatas.update({"full_page": page_content})
 

--- a/app/tests/test_document_loader.py
+++ b/app/tests/test_document_loader.py
@@ -98,25 +98,25 @@ class TestDocumentLoader(unittest.TestCase):
         file_path = f'{self.path}/{self.file_name}.pdf'
         data_loader = DataLoader(pdf_loader, file_path)
         raw_text = data_loader.raw_text()
-        self.assertEqual(raw_text, self.text_string.lower())
+        self.assertEqual(raw_text, self.text_string)
 
     def test_load_txt(self):
         file_path = f'{self.path}/{self.file_name}.txt'
         data_loader = DataLoader(txt_loader, file_path)
         raw_text = data_loader.raw_text()
-        self.assertEqual(raw_text, self.text_string.lower())
+        self.assertEqual(raw_text, self.text_string)
 
     def test_load_udocx(self):
         file_path = f'{self.path}/{self.file_name}.docx'
         data_loader = DataLoader(u_docx_loader, file_path)
         raw_text = data_loader.raw_text()
-        self.assertEqual(raw_text, self.text_string.lower())
+        self.assertEqual(raw_text, self.text_string)
 
     def test_load_docx(self):
         file_path = f'{self.path}/{self.file_name}.docx'
         data_loader = DataLoader(docx_loader, file_path)
         raw_text = data_loader.raw_text()
-        self.assertEqual(raw_text, self.text_string.lower())
+        self.assertEqual(raw_text, self.text_string)
 
     def test_load_xlsx(self):
         file_path = f'{self.path}/{self.file_name}.xlsx'


### PR DESCRIPTION
Remover .lower() of all the strings to avoid losing information in the indexing process and further model generation.